### PR TITLE
Fixing broken script

### DIFF
--- a/go.spec
+++ b/go.spec
@@ -10,6 +10,8 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires:  gcc
 AutoReqProv:    no
 
+%define debug_package %{nil}
+
 %define __spec_install_post %{nil}
 
 %description


### PR DESCRIPTION
Debug package was crashing the build because certain binaries are missing.
Same problem/solution here:
https://www.redhat.com/archives/shrike-list/2003-April/msg02179.html
